### PR TITLE
Prebuild and publish binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 
 env:
   - CXX=g++-4.9
+  - CXX=clang++
+
 addons:
   apt:
     sources:
@@ -11,12 +13,37 @@ addons:
 
 language: node_js
 
+os:
+  - linux
+  - osx
+
+osx_image: xcode10
+
 node_js:
-  - "4"
-  - "6"
   - "8"
   - "9"
+  - "10"
+  - "12"
+
+jobs:
+  exclude:
+      - os: osx
+        env: CXX=g++-4.9
+      - os: linux
+        env: CXX=clang++
+
+install:
+  - npm install --build-from-source
 
 after_success:
   - npm install coveralls
   - nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls
+
+deploy:
+  provider: script
+  script:
+    - npm run upload-posix
+  skip_cleanup: true
+  on:
+    tags: true
+    repo: node-ffi-napi/ref-napi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,10 @@ environment:
   # Test against these versions of Node.js and io.js
   matrix:
     # node.js
-    - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "9"
+    - nodejs_version: "10"
+    - nodejs_version: "12"
 
 platform:
   - x86
@@ -35,3 +36,7 @@ build: off
 
 # Set build version format here instead of in the admin panel.
 version: "{build}"
+
+deploy_script:
+  - IF "%APPVEYOR_REPO_TAG%" == "true" (npm run upload-windows)
+  - IF NOT "%APPVEYOR_REPO_TAG%" == "true" (echo 'Not tagged, skipping deploy')

--- a/package.json
+++ b/package.json
@@ -30,13 +30,17 @@
   },
   "main": "./lib/ref.js",
   "scripts": {
+    "upload-posix": "prebuild -t $npm_config_node_version -u $PREBUILD_GITHUB_TOKEN --include-regex \"binding\\.node$\"",
+    "upload-windows": "prebuild -t %npm_config_node_version% -u %PREBUILD_GITHUB_TOKEN% --include-regex \"binding\\.node$\"",
     "docs": "node docs/compile",
-    "test": "nyc mocha -gc"
+    "test": "nyc mocha -gc",
+    "install": "prebuild-install --verbose || node-gyp rebuild"
   },
   "dependencies": {
     "bindings": "^1.3.0",
     "debug": "^3.1.0",
-    "node-addon-api": "^2.0.0"
+    "node-addon-api": "^2.0.0",
+    "prebuild-install": "^5.3.3"
   },
   "devDependencies": {
     "dox": "0.9.0",
@@ -44,7 +48,8 @@
     "jade": "^1.11.0",
     "marked": "^0.7.0",
     "mocha": "^5.0.0",
-    "nyc": "^12.0.1",
+    "nyc": "^15.0.0",
+    "prebuild": "^10.0.0",
     "weak-napi": "1"
   }
 }


### PR DESCRIPTION
This is the equivalent change to https://github.com/node-ffi-napi/node-ffi-napi/pull/63, and comes with the same caveats etc.

Like the other PR, this drops CI testing (although not compatibility) for node < 8. As there, we could work around this, but they're both EOL for quite some time now. Wouldn't seem unreasonable to me to do a breaking release and explicitly stop supporting those entirely, but your call.

Tested by publishing [@httptoolkit/ref-napi](https://www.npmjs.com/package/@httptoolkit/ref-napi), you can see the corresponding CI-published binaries at https://github.com/httptoolkit/ref-napi/releases.

This is also using prebuild, not prebuildify, but it should be very easy to switch this PR over too, if that's the way we want to go.