### PR TITLE
Add support for NAPI 6

### DIFF
--- a/include/ref-napi.h
+++ b/include/ref-napi.h
@@ -1,7 +1,9 @@
 #ifndef REF_NAPI_H
 #define REF_NAPI_H
 
+#if !defined(NAPI_VERSION) || NAPI_VERSION < 6
 #include <get-symbol-from-current-process.h>
+#endif
 #include "napi.h"
 
 // The definitions in this file are intended to be used by node-ffi-napi.

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -24,6 +24,7 @@ using namespace Napi;
 
 namespace {
 
+#if !defined(NAPI_VERSION) || NAPI_VERSION < 6
 napi_status napix_set_instance_data(
     napi_env env, void* data, napi_finalize finalize_cb, void* finalize_hint) {
   typedef napi_status (*napi_set_instance_data_fn)(
@@ -50,6 +51,17 @@ napi_status napix_get_instance_data(
     return napi_generic_failure;
   return napi_get_instance_data__(env, data);
 }
+#else // NAPI_VERSION >= 6
+napi_status napix_set_instance_data(
+    napi_env env, void* data, napi_finalize finalize_cb, void* finalize_hint) {
+  return napi_set_instance_data(env, data, finalize_cb, finalize_hint);
+}
+
+napi_status napix_get_instance_data(
+    napi_env env, void** data) {
+  return napi_get_instance_data(env, data);
+}
+#endif
 
 // used by the Int64 functions to determine whether to return a Number
 // or String based on whether or not a Number will lose precision.


### PR DESCRIPTION
Would you support NAPI_VERSION  6 without using get-symbol-from-current-process? napi_set_instance_data and napi_get_instance_data were added.

Sorry, this is my first time working with native addons, but I think I have this added correctly. Testing with latest nw using node 14.7.

Thank you!