### PR TITLE
Rename bindings to prevent overflow in Jest

### DIFF
--- a/lib/ref.js
+++ b/lib/ref.js
@@ -716,10 +716,9 @@ exports.writeObject = function writeObject (buf, offset, obj) {
  * @param {Buffer} buffer A Buffer instance to write _pointer to.
  * @param {Number} offset The offset on the Buffer to start writing at.
  * @param {Buffer} pointer The Buffer instance whose memory address will be written to _buffer_.
+ * @name _writePointer
  * @api private
  */
-
-exports._writePointer = exports.writePointer;
 
 /**
  * Writes the memory address of _pointer_ to _buffer_ at the specified _offset_.

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -683,7 +683,14 @@ exports._attach = function _attach (buf, obj) {
   buf[kAttachedRefs].push(obj);
 }
 
-exports._writeObject = exports.writeObject;
+/**
+ * @param {Buffer} buffer
+ * @param {Number} offset
+ * @param {Object} object
+ * @name _writeObject
+ * @api private
+ */
+
 /**
  * Writes a pointer to _object_ into _buffer_ at the specified _offset.
  *
@@ -752,10 +759,9 @@ exports.writePointer = function writePointer (buf, offset, ptr) {
  * @param {Number} size The `length` property of the returned Buffer.
  * @param {Number} offset The offset of the Buffer to begin from.
  * @return {Buffer} A new Buffer instance with the same memory address as _buffer_, and the requested _size_.
+ * @name _reinterpret
  * @api private
  */
-
-exports._reinterpret = exports.reinterpret;
 
 /**
  * Returns a new Buffer instance with the specified _size_, with the same memory
@@ -786,10 +792,9 @@ exports.reinterpret = function reinterpret (buffer, size, offset) {
  * @param {Number} size The number of sequential, aligned `NULL` bytes that are required to terminate the buffer.
  * @param {Number} offset The offset of the Buffer to begin from.
  * @return {Buffer} A new Buffer instance with the same memory address as _buffer_, and a variable `length` that is terminated by _size_ NUL bytes.
+ * @name _reinterpretUntilZeros
  * @api private
  */
-
-exports._reinterpretUntilZeros = exports.reinterpretUntilZeros;
 
 /**
  * Accepts a `Buffer` instance and a number of `NULL` bytes to read from the

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -677,7 +677,7 @@ Object Init(Env env, Object exports) {
   exports["hexAddress"] = Function::New(env, HexAddress);
   exports["isNull"] = Function::New(env, IsNull);
   exports["readObject"] = Function::New(env, ReadObject);
-  exports["writeObject"] = Function::New(env, WriteObject);
+  exports["_writeObject"] = Function::New(env, WriteObject);
   exports["readPointer"] = Function::New(env, ReadPointer);
   exports["_writePointer"] = Function::New(env, WritePointer);
   exports["readInt64"] = Function::New(env, ReadInt64);
@@ -685,8 +685,8 @@ Object Init(Env env, Object exports) {
   exports["readUInt64"] = Function::New(env, ReadUInt64);
   exports["writeUInt64"] = Function::New(env, WriteUInt64);
   exports["readCString"] = Function::New(env, ReadCString);
-  exports["reinterpret"] = Function::New(env, ReinterpretBuffer);
-  exports["reinterpretUntilZeros"] = Function::New(env, ReinterpretBufferUntilZeros);
+  exports["_reinterpret"] = Function::New(env, ReinterpretBuffer);
+  exports["_reinterpretUntilZeros"] = Function::New(env, ReinterpretBufferUntilZeros);
   return exports;
 }
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -679,7 +679,7 @@ Object Init(Env env, Object exports) {
   exports["readObject"] = Function::New(env, ReadObject);
   exports["writeObject"] = Function::New(env, WriteObject);
   exports["readPointer"] = Function::New(env, ReadPointer);
-  exports["writePointer"] = Function::New(env, WritePointer);
+  exports["_writePointer"] = Function::New(env, WritePointer);
   exports["readInt64"] = Function::New(env, ReadInt64);
   exports["writeInt64"] = Function::New(env, WriteInt64);
   exports["readUInt64"] = Function::New(env, ReadUInt64);


### PR DESCRIPTION
This is a fix for https://github.com/node-ffi-napi/ref-napi/issues/16, an issue that appears (especially in tests) when `writePointer` turns into an infinitely recursive call and overflows the stack.

This PR renames the native binding to already have the underscore to prevent the loop from ever being created.