### PR TITLE
Target Node.js v14 in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     # node.js
     - nodejs_version: "10"
     - nodejs_version: "12"
+    - nodejs_version: "14"
 
 platform:
   - x86

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ref-napi",
   "description": "Turn Buffer instances into \"pointers\"",
   "engines": {
-    "node": ">= 6.0"
+    "node": ">= 10.0"
   },
   "keywords": [
     "native",

--- a/test/pointer.js
+++ b/test/pointer.js
@@ -43,12 +43,14 @@ describe('pointer', function() {
     parent = null;
     gc();
     setImmediate(() => {
-      assert(parent_gc, '"parent" has not been garbage collected');
-      gc();
       setImmediate(() => {
+        assert(parent_gc, '"parent" has not been garbage collected');
+        gc();
         setImmediate(() => {
-          assert(child_gc, '"child" has not been garbage collected');
-          done();
+          setImmediate(() => {
+            assert(child_gc, '"child" has not been garbage collected');
+            done();
+          });
         });
       });
     });

--- a/test/reinterpret.js
+++ b/test/reinterpret.js
@@ -52,8 +52,10 @@ describe('reinterpret()', function() {
     other = null;
     gc();
     setImmediate(() => {
-      assert(otherGCd, '"other" has not been garbage collected');
-      assert(origGCd, '"buf" has not been garbage collected');
+      setImmediate(() => {
+        assert(otherGCd, '"other" has not been garbage collected');
+        assert(origGCd, '"buf" has not been garbage collected');
+      });
     });
   });
 });


### PR DESCRIPTION
- Tests in `.travis.yml` target Node.js v14.
- Tests in `appveyor.yml` should also target Node.js v14.
- Updates `engines` in `package.json` to Node.js >= 10.
- Includes test-fixes by @addaleax.