### PR TITLE
src: keep reference buffer alive longer

### DIFF
--- a/lib/ref.js
+++ b/lib/ref.js
@@ -746,8 +746,12 @@ exports.writeObject = function writeObject (buf, offset, obj) {
 
 exports.writePointer = function writePointer (buf, offset, ptr) {
   debug('writing pointer to buffer', buf, offset, ptr);
+  // Passing true as a fourth parameter does an a stronger
+  // version of attach which ensures ptr is only collected after
+  // the finalizer for buf has run. See
+  // https://github.com/node-ffi-napi/ref-napi/issues/54
+  // for why this is necessary
   exports._writePointer(buf, offset, ptr, true);
-  exports._attach(buf, ptr);
 };
 
 /**

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -746,7 +746,7 @@ exports.writeObject = function writeObject (buf, offset, obj) {
 
 exports.writePointer = function writePointer (buf, offset, ptr) {
   debug('writing pointer to buffer', buf, offset, ptr);
-  exports._writePointer(buf, offset, ptr);
+  exports._writePointer(buf, offset, ptr, true);
   exports._attach(buf, ptr);
 };
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -355,6 +355,16 @@ void WritePointer(const CallbackInfo& args) {
   if (input.IsNull()) {
     *reinterpret_cast<char**>(ptr) = nullptr;
   } else {
+    // create a node-api reference and finalizer to ensure that
+    // the buffer whoes pointer is written can only be
+    // collected after the finalizers for the buffer
+    // to which the pointer was written have already run
+    Reference<Value>* ref = new Reference<Value>;
+    *ref = Persistent(args[2]);
+    args[0].As<Object>().AddFinalizer([](Env env, Reference<Value>* ref) {
+      delete ref;
+    }, ref);
+
     char* input_ptr = GetBufferData(input);
     *reinterpret_cast<char**>(ptr) = input_ptr;
   }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -355,15 +355,17 @@ void WritePointer(const CallbackInfo& args) {
   if (input.IsNull()) {
     *reinterpret_cast<char**>(ptr) = nullptr;
   } else {
-    // create a node-api reference and finalizer to ensure that
-    // the buffer whoes pointer is written can only be
-    // collected after the finalizers for the buffer
-    // to which the pointer was written have already run
-    Reference<Value>* ref = new Reference<Value>;
-    *ref = Persistent(args[2]);
-    args[0].As<Object>().AddFinalizer([](Env env, Reference<Value>* ref) {
-      delete ref;
-    }, ref);
+    if ((args.Length() == 4) && (args[3].As<Boolean>() == true)) {
+      // create a node-api reference and finalizer to ensure that
+      // the buffer whoes pointer is written can only be
+      // collected after the finalizers for the buffer
+      // to which the pointer was written have already run
+      Reference<Value>* ref = new Reference<Value>;
+      *ref = Persistent(args[2]);
+      args[0].As<Object>().AddFinalizer([](Env env, Reference<Value>* ref) {
+        delete ref;
+      }, ref);
+    }
 
     char* input_ptr = GetBufferData(input);
     *reinterpret_cast<char**>(ptr) = input_ptr;


### PR DESCRIPTION
Keep a buffer written by WritePointer alive
until the finalizers for the buffer to which
the pointer has been run have been executed:

Refs: https://github.com/node-ffi-napi/ref-napi/issues/54

Signed-off-by: Michael Dawson <mdawson@devrus.com>