### PR TITLE
fix docs/compile.js error

### DIFF
--- a/docs/compile.js
+++ b/docs/compile.js
@@ -146,7 +146,7 @@ function markdown (code) {
  */
 
 function highlight (code, lang) {
-  if (!hljs.LANGUAGES.hasOwnProperty(lang)) {
+  if (hljs.listLanguages().indexOf(lang) === -1) {
     lang = 'javascript'
   }
   return hljs.highlight(lang, code).value


### PR DESCRIPTION
without:

```
$ npm run docs

> ref-napi@3.0.3 docs
> node docs/compile

/Users/brandonros/Desktop/ref-napi/node_modules/marked/src/marked.js:121
    throw e;
    ^

TypeError: Cannot read property 'hasOwnProperty' of undefined
Please report this to https://github.com/markedjs/marked.
    at Object.highlight (/Users/brandonros/Desktop/ref-napi/docs/compile.js:149:23)
    at Renderer.code (/Users/brandonros/Desktop/ref-napi/node_modules/marked/src/Renderer.js:18:32)
    at Parser.parse (/Users/brandonros/Desktop/ref-napi/node_modules/marked/src/Parser.js:93:32)
    at Function.parse (/Users/brandonros/Desktop/ref-napi/node_modules/marked/src/Parser.js:27:19)
    at marked (/Users/brandonros/Desktop/ref-napi/node_modules/marked/src/marked.js:113:19)
    at markdown (/Users/brandonros/Desktop/ref-napi/docs/compile.js:137:10)
    at /Users/brandonros/Desktop/ref-napi/docs/compile.js:79:19
    at Array.forEach (<anonymous>)
    at /Users/brandonros/Desktop/ref-napi/docs/compile.js:77:10
    at Array.forEach (<anonymous>)
```