### PR TITLE
Adding a feature to create an external ArrayBuffer from given address…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
-ref-napi
+ref-napi-ex
 ========
 ### Turn Buffer instances into "pointers"
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/node-ffi-napi/ref-napi.svg)](https://greenkeeper.io/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/luxel/ref-napi.svg)](https://greenkeeper.io/)
 
-[![NPM Version](https://img.shields.io/npm/v/ref-napi.svg?style=flat)](https://npmjs.org/package/ref-napi)
-[![NPM Downloads](https://img.shields.io/npm/dm/ref-napi.svg?style=flat)](https://npmjs.org/package/ref-napi)
-[![Build Status](https://travis-ci.org/node-ffi-napi/ref-napi.svg?style=flat&branch=latest)](https://travis-ci.org/node-ffi-napi/ref-napi?branch=latest)
-[![Coverage Status](https://coveralls.io/repos/node-ffi-napi/ref-napi/badge.svg?branch=latest)](https://coveralls.io/r/node-ffi-napi/ref-napi?branch=latest)
-[![Dependency Status](https://david-dm.org/node-ffi-napi/ref-napi.svg?style=flat)](https://david-dm.org/node-ffi-napi/ref-napi)
+[![NPM Version](https://img.shields.io/npm/v/ref-napi-ex.svg?style=flat)](https://npmjs.org/package/ref-napi-ex)
+[![NPM Downloads](https://img.shields.io/npm/dm/ref-napi-ex.svg?style=flat)](https://npmjs.org/package/ref-napi-ex)
+[![Build Status](https://travis-ci.org/luxel/ref-napi.svg?style=flat&branch=latest)](https://travis-ci.org/luxel/ref-napi?branch=latest)
+[![Coverage Status](https://coveralls.io/repos/luxel/ref-napi/badge.svg?branch=latest)](https://coveralls.io/r/luxel/ref-napi?branch=latest)
+[![Dependency Status](https://david-dm.org/luxel/ref-napi.svg?style=flat)](https://david-dm.org/luxel/ref-napi)
 
 This module is inspired by the old `Pointer` class from node-ffi, but with the
 intent of using Node's fast `Buffer` instances instead of a slow C++ `Pointer`
 class. These two concepts were previously very similar, but now this module
 brings over the functionality that Pointers had and Buffers are missing, so
 now Buffers are a lot more powerful.
+
+ref-napi-ex is a fork from [ref-napi](https://github.com/luxel/ref-napi) (Thanks you Anna Henningsen for bringing us the excellent repo!). On top of ref-napi, an API `ref.readExternalArrayBuffer` is added which can create "External" `ArrayBuffer` from any given memory address.
 
 ### Features:
 
@@ -25,7 +27,7 @@ now Buffers are a lot more powerful.
  * A "type" convention, so that you can specify a buffer as an `int *`,
    and reference/dereference at will.
  * Offers a buffer instance representing the `NULL` pointer
-
+ * Creates an "External" `ArrayBuffer` instance from given memory address and size, without creating new memory buffer. (Behind the scene, it uses `napi_create_external_arraybuffer`).
 
 Installation
 ------------
@@ -33,7 +35,7 @@ Installation
 Install with `npm`:
 
 ``` bash
-$ npm install ref-napi
+$ npm install ref-napi-ex
 ```
 
 
@@ -43,7 +45,7 @@ Examples
 #### referencing and derefencing
 
 ``` js
-var ref = require('ref-napi')
+var ref = require('ref-napi-ex')
 
 // so we can all agree that a buffer with the int value written
 // to it could be represented as an "int *"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "ref-napi",
-  "description": "Turn Buffer instances into \"pointers\"",
+  "name": "ref-napi-ex",
+  "description": "Fork of node-ffi-napi/ref-napi with external ArrayBuffer support",
   "engines": {
-    "node": ">= 10.0"
+    "node": ">= 12.0"
   },
   "keywords": [
     "native",
@@ -21,12 +21,12 @@
     "64",
     "napi"
   ],
-  "version": "3.0.3",
+  "version": "3.0.4",
   "license": "MIT",
-  "author": "Anna Henningsen <anna@addaleax.net>",
+  "author": "Luxel Tao (https://github.com/luxel)",
   "repository": {
     "type": "git",
-    "url": "git://github.com/node-ffi-napi/ref-napi.git"
+    "url": "git://github.com/luxel/ref-napi.git"
   },
   "main": "./lib/ref.js",
   "scripts": {
@@ -34,6 +34,7 @@
     "test": "nyc mocha --expose-gc",
     "install": "node-gyp-build",
     "prebuild": "prebuildify --napi --tag-armv",
+    "prebuild-node14": "prebuildify --napi --tag-armv --target 14.17.6",
     "prepack": "prebuildify-ci download && ([ $(ls prebuilds | wc -l) = '5' ] || (echo 'Some prebuilds are missing'; exit 1))"
   },
   "dependencies": {

--- a/test/external_arraybuffer.js
+++ b/test/external_arraybuffer.js
@@ -1,0 +1,35 @@
+'use strict';
+const assert = require('assert');
+const ref = require('../');
+const inspect = require('util').inspect;
+
+describe('external_arraybuffer', function() {
+
+  it('should get an array buffer with number address', function() {
+    const buf = Buffer.from('hello' + '\0');
+    const address = ref.address(buf);
+    const ab = ref.readExternalArrayBuffer(address, 6);
+    assert.strictEqual(typeof ab, 'object');
+    const buffer = Buffer.from(ab);
+    const address2 = ref.address(buffer);
+    assert.strictEqual(address, address2);
+    assert.strictEqual('hello', buffer.readCString());
+    // when buffer gets changed, the original buf should be changed too
+    buffer.writeCString('olleh');
+    assert.strictEqual('olleh', buf.readCString());
+  });
+  
+  it('should get an array buffer with string address', function() {   
+    const buf = Buffer.from('hello' + '\0'); 
+    const hexAddress = ref.hexAddress(buf);
+    const ab = ref.readExternalArrayBuffer('0x' + hexAddress, 6);
+    assert.strictEqual(typeof ab, 'object');
+    const buffer = Buffer.from(ab);
+    const address2 = ref.hexAddress(buffer);
+    assert.strictEqual(hexAddress, address2);
+    assert.strictEqual('hello', buffer.readCString());
+    // when buffer gets changed, the original buf should be changed too
+    buffer.writeCString('olleh');
+    assert.strictEqual('olleh', buf.readCString());
+  });
+});


### PR DESCRIPTION
Adding a feature to create an external ArrayBuffer from given address without allocating new memory, using napi_create_external_arraybuffer. This could be useful for manipulating large data buffer returned by external C++ module.