### PR TITLE
Change to using std::min() when allocating Buffers

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -105,12 +105,12 @@ class InstanceData final : public RefNapi::Instance {
 
     auto it = pointer_to_orig_buffer.find(ptr);
     if (it != pointer_to_orig_buffer.end()) {
+      it->second.finalizer_count++;
       if (!it->second.ab.Value().IsEmpty()) {
         // Already have a valid entry, nothing to do.
         return;
       }
       it->second.ab.Reset(buf, 0);
-      it->second.finalizer_count++;
     } else {
       pointer_to_orig_buffer.emplace(ptr, ArrayBufferEntry {
         Reference<ArrayBuffer>::New(buf, 0),
@@ -140,7 +140,7 @@ class InstanceData final : public RefNapi::Instance {
     if (it != pointer_to_orig_buffer.end())
       ab = it->second.ab.Value();
 
-    if (ab.IsEmpty()) {
+    if (ab.IsEmpty() || (ab.ByteLength() < length)) {
       length = std::min<size_t>(length, kMaxLength);
       ab = Buffer<char>::New(env, ptr, length, [this](Env env, char* ptr) {
         UnregisterArrayBuffer(ptr);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -141,7 +141,7 @@ class InstanceData final : public RefNapi::Instance {
       ab = it->second.ab.Value();
 
     if (ab.IsEmpty()) {
-      length = std::max<size_t>(length, kMaxLength);
+      length = std::min<size_t>(length, kMaxLength);
       ab = Buffer<char>::New(env, ptr, length, [this](Env env, char* ptr) {
         UnregisterArrayBuffer(ptr);
       }).ArrayBuffer();


### PR DESCRIPTION
This will result in Buffers being allocated to the size requested up to kMaxLength (0x3fffffff) instead of the current behavior of always allocating kMaxLength.  Since these buffers are allocated in the node external memory (limited to 64M) the old behavior would very quickly cause massive GC pressure as the GC is triggered on each new Buffer allocation once the node external memory limit is reached.  It appears the old behavior was not intentional and should have always been std::min().  This should fix #72 