### PR TITLE
Fix severe node performance issue due to buffer allocation bug, fix undefined behavior which breaks node > 18.7.0

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -105,12 +105,12 @@ class InstanceData final : public RefNapi::Instance {
 
     auto it = pointer_to_orig_buffer.find(ptr);
     if (it != pointer_to_orig_buffer.end()) {
+      it->second.finalizer_count++;
       if (!it->second.ab.Value().IsEmpty()) {
         // Already have a valid entry, nothing to do.
         return;
       }
       it->second.ab.Reset(buf, 0);
-      it->second.finalizer_count++;
     } else {
       pointer_to_orig_buffer.emplace(ptr, ArrayBufferEntry {
         Reference<ArrayBuffer>::New(buf, 0),
@@ -140,7 +140,7 @@ class InstanceData final : public RefNapi::Instance {
     if (it != pointer_to_orig_buffer.end())
       ab = it->second.ab.Value();
 
-    if (ab.IsEmpty()) {
+    if (ab.IsEmpty() || (ab.ByteLength() < length)) {
       length = std::min<size_t>(length, kMaxLength);
       ab = Buffer<char>::New(env, ptr, length, [this](Env env, char* ptr) {
         UnregisterArrayBuffer(ptr);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -166,8 +166,15 @@ class InstanceData final : public RefNapi::Instance {
  */
 
 Value WrapPointer(Env env, char* ptr, size_t length) {
-  if (ptr == nullptr)
+  if (ptr == nullptr) {
     length = 0;
+  } else if (length == 0) {
+    // If length is 0 N-API doesn't guarantee it will save/restore ptr normally.
+    // For example, see https://nodejs.org/api/n-api.html#napi_get_typedarray_info
+    // "[out] data: ... If the length of the array is 0, this may be NULL or any
+    // other pointer value."
+    length = 1;
+  }
 
   InstanceData* data;
   if (ptr != nullptr && (data = InstanceData::Get(env)) != nullptr) {

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -141,7 +141,7 @@ class InstanceData final : public RefNapi::Instance {
       ab = it->second.ab.Value();
 
     if (ab.IsEmpty()) {
-      length = std::max<size_t>(length, kMaxLength);
+      length = std::min<size_t>(length, kMaxLength);
       ab = Buffer<char>::New(env, ptr, length, [this](Env env, char* ptr) {
         UnregisterArrayBuffer(ptr);
       }).ArrayBuffer();


### PR DESCRIPTION
Fixes two important issues:

1. Fixes a severe node performance issue due to buffer allocation bug, this fix comes from @doggkruse in #73.
2. Fixes undefined behavior which breaks node > 18.7.0. I believe I tracked down the issue to the "GetBackingStore" updates referenced in the 18.8.0 release notes. Release notes here: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md. The issue was addressed in several PRs created to address this issue: https://github.com/nodejs/node/issues/32226.

Please let me know if any further work is needed, I would be happy to help, this would be nice to get merged in and released. Thank you!