### PR TITLE
Fix: Known Issues In Electron `v20.x.x` and later. 

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -167,7 +167,7 @@ class InstanceData final : public RefNapi::Instance {
 
 Value WrapPointer(Env env, char* ptr, size_t length) {
   if (ptr == nullptr)
-    length = 0;
+    return Buffer<char>::New(env, 0);
 
   InstanceData* data;
   if (ptr != nullptr && (data = InstanceData::Get(env)) != nullptr) {


### PR DESCRIPTION
https://github.com/nodejs/node-addon-api/blob/main/doc/buffer.md
https://github.com/nodejs/node-addon-api/blob/main/doc/external_buffer.md
## Close

- Using an unacceptable `Buffer<char>::new` inside WrapPointer() will eventually cause problems in higher versions of Electron.
  - There is logic to access WrapPointer() from `ffi-napi` logic.

- To use `Buffer::NewOrCopy`, raise the node-addon-api version.
  - However, changing `Buffer::NewOrCopy` from `Buffer::New` is a behavioral change and causes many test code failures...